### PR TITLE
Exclude overlays from state and gradable data

### DIFF
--- a/sketch_tool/lib/gradeable-manager.js
+++ b/sketch_tool/lib/gradeable-manager.js
@@ -23,6 +23,8 @@ export default class GradeableManager {
       };
 
       this.registry.forEach((entry) => {
+        // Ignore plugins with overlay config set to true
+        if (entry.overlay) return;
         response.data[entry.id] = entry.getGradeable();
         response.meta.dataVersions[entry.id] = entry.version; // TODO: versioning
       });

--- a/sketch_tool/lib/plugins/base-plugin.js
+++ b/sketch_tool/lib/plugins/base-plugin.js
@@ -56,6 +56,7 @@ export default class BasePlugin {
     app.registerState({
       id: this.params.id,
       dataVersion: this.params.version,
+      overlay: this.params.overlay || false,
       getState: () => this.state,
       setState: (state) => {
         this.state = state;
@@ -66,6 +67,7 @@ export default class BasePlugin {
     app.registerGradeable({
       id: this.params.id,
       version: this.params.gradeableVersion,
+      overlay: this.params.overlay || false,
       getGradeable: () => this.getGradeable(),
     });
     // Only add a button to toolbar is the plugin is not readonly

--- a/sketch_tool/lib/state-manager.js
+++ b/sketch_tool/lib/state-manager.js
@@ -19,6 +19,8 @@ export default class StateManager {
   getPluginState() {
     const state = {};
     this.registry.forEach((entry) => {
+      // Ignore plugins with overlay config set to true
+      if (entry.overlay) return;
       state[entry.id] = entry.getState();
     });
     return deepCopy(state); // Use deepCopy to keep plugin state isolated
@@ -27,6 +29,8 @@ export default class StateManager {
   setPluginState(state) {
     state = deepCopy(state); // Use deepCopy to keep plugin state isolated
     this.registry.forEach((entry) => {
+      // Ignore plugins with overlay config set to true
+      if (entry.overlay) return;
       // eslint-disable-next-line no-prototype-builtins
       if (state.hasOwnProperty(entry.id)) entry.setState(state[entry.id]);
     });
@@ -44,6 +48,8 @@ export default class StateManager {
       };
 
       this.registry.forEach((entry) => {
+        // Ignore plugins with overlay config set to true
+        if (entry.overlay) return;
         // TODO: only save state when plugins actually have state
         response.data[entry.id] = entry.getState();
         response.meta.dataVersions[entry.id] = entry.dataVersion;
@@ -62,6 +68,8 @@ export default class StateManager {
       // TODO: format version checking
 
       this.registry.forEach((entry) => {
+        // Ignore plugins with overlay config set to true
+        if (entry.overlay) return;
         // TODO: plugin version checking?
         // eslint-disable-next-line no-prototype-builtins
         if (state.data.hasOwnProperty(entry.id))
@@ -78,6 +86,8 @@ export default class StateManager {
   loadInitialState() {
     try {
       this.registry.forEach((entry) => {
+        // Ignore plugins with overlay config set to true
+        if (entry.overlay) return;
         // eslint-disable-next-line no-prototype-builtins
         if (this.initialState.hasOwnProperty(entry.id))
           entry.setState(this.initialState[entry.id]);

--- a/sketch_tool/package.json
+++ b/sketch_tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prairielearn/sketchresponse",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "A configurable JavaScript front-end drawing tool with plugin components - adapted for use in PrairieLearn",
   "private": false,
   "license": "LGPL-2.1",

--- a/sketchresponse/grader_lib/MultiFunction.py
+++ b/sketchresponse/grader_lib/MultiFunction.py
@@ -194,7 +194,8 @@ class MultiFunction(Function):
 
         return bool(max_dist < 0.4 * self.tolerance["straight_line"] * length)
 
-    def collapse_ranges(self, ranges: list[list[float]]) -> list[list[float]]:
+    @staticmethod
+    def collapse_ranges(ranges: list[list[float]]) -> list[list[float]]:
         all_ranges = ranges
         if len(ranges) == 1:
             return ranges


### PR DESCRIPTION
Currently, the state/gradable info of the solution overlays is sent to the server and gets added to the initial rendering data for the submission. We do not want overlays to ever become part of a student's submission, so this explicitly excludes them on the client side.

Also, this contains a minor change that turns a grading helper method into a static method since it isn't dependent on `self`.
