### PR TITLE
Fix state handling

### DIFF
--- a/sketch_tool/lib/state-manager.js
+++ b/sketch_tool/lib/state-manager.js
@@ -19,8 +19,6 @@ export default class StateManager {
   getPluginState() {
     const state = {};
     this.registry.forEach((entry) => {
-      // Ignore plugins with overlay config set to true
-      if (entry.overlay) return;
       state[entry.id] = entry.getState();
     });
     return deepCopy(state); // Use deepCopy to keep plugin state isolated
@@ -29,8 +27,6 @@ export default class StateManager {
   setPluginState(state) {
     state = deepCopy(state); // Use deepCopy to keep plugin state isolated
     this.registry.forEach((entry) => {
-      // Ignore plugins with overlay config set to true
-      if (entry.overlay) return;
       // eslint-disable-next-line no-prototype-builtins
       if (state.hasOwnProperty(entry.id)) entry.setState(state[entry.id]);
     });
@@ -68,8 +64,6 @@ export default class StateManager {
       // TODO: format version checking
 
       this.registry.forEach((entry) => {
-        // Ignore plugins with overlay config set to true
-        if (entry.overlay) return;
         // TODO: plugin version checking?
         // eslint-disable-next-line no-prototype-builtins
         if (state.data.hasOwnProperty(entry.id))
@@ -86,8 +80,6 @@ export default class StateManager {
   loadInitialState() {
     try {
       this.registry.forEach((entry) => {
-        // Ignore plugins with overlay config set to true
-        if (entry.overlay) return;
         // eslint-disable-next-line no-prototype-builtins
         if (this.initialState.hasOwnProperty(entry.id))
           entry.setState(this.initialState[entry.id]);

--- a/sketch_tool/package.json
+++ b/sketch_tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prairielearn/sketchresponse",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A configurable JavaScript front-end drawing tool with plugin components - adapted for use in PrairieLearn",
   "private": false,
   "license": "LGPL-2.1",


### PR DESCRIPTION
This fixes a bug introduced by the previous version where state information for overlays is also ignored in cases where it should be used (e.g., when loading the initial state).